### PR TITLE
Make things work on 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ deps/src/Makefile
 deps/src/cmake_install.cmake
 deps/src/libpolymake.so
 local
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "PolymakeWrap"
+uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
+repo = "https://github.com/oscar-system/PolymakeWrap.jl.git"
+version = "0.1.0"
+
+[deps]
+CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["DynamicPolynomials", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DynamicPolynomials", "Test"]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.6
+julia 0.7
+CxxWrap

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,7 +5,7 @@ import Pkg
 # test whether polymake config is available in path
 pm_config = nothing
 try
-    global pm_config = chomp(read(`which polymake-config`, String))
+    global pm_config = chomp(read(`command -v polymake-config`, String))
 catch
     if haskey(ENV, "POLYMAKE_CONFIG")
         global pm_config = ENV["POLYMAKE_CONFIG"]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -73,7 +73,7 @@ julia_include = joinpath(Sys.BINDIR, "..", "include")
 julia_lib = joinpath(Sys.BINDIR, "..", "lib")
 julia_exec = joinpath(Sys.BINDIR , "julia")
 
-cd("src")
+cd(joinpath(@__DIR__, "src"))
 
 run(`cmake -DJulia_EXECUTABLE=$julia_exec -DJlCxx_DIR=$jlcxx_cmake_dir -DJuliaIncludeDir=$julia_include -DJULIA_LIB_DIR=$julia_lib -Dpolymake_includes=$pm_includes -Dpolymake_ldflags=$pm_ldflags -Dpolymake_libs=$pm_libraries -Dpolymake_cflags=$pm_cflags -DCMAKE_INSTALL_LIBDIR=lib .`)
 run(`make`)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,65 +1,79 @@
 using CxxWrap
+import Pkg
 
-## build polymake, using Nemo's GMP and MPFR
 
-if ! haskey(ENV, "POLYMAKE_CONFIG")
-    const oldwdir = pwd()
-    const pkgdir = Pkg.dir("PolymakeWrap")
-    const nemodir = Pkg.dir("Nemo")
-
-    wdir = "$pkgdir/deps"
-    vdir = "$pkgdir/local"
-    nemovdir = "$nemodir/local"
-
-    LDFLAGS = "-Wl,-rpath,$vdir/lib -Wl,-R$vdir/lib -Wl,-R$nemovdir/lib -Wl,-R\$\$ORIGIN/../share/julia/site/v$(VERSION.major).$(VERSION.minor)/Polymake/local/lib"
-
-    cd(wdir)
-
-    const polymake = joinpath(wdir, "polymake")
-
-    try
-      run(`git clone https://github.com/polymake/polymake.git`)
-    catch
-      cd(polymake)
-      try
-         run(`git pull --rebase`)
-      catch
-      end
-      cd(wdir)
+# test whether polymake config is available in path
+pm_config = nothing
+try
+    global pm_config = chomp(read(`which polymake-config`, String))
+catch
+    if haskey(ENV, "POLYMAKE_CONFIG")
+        global pm_config = ENV["POLYMAKE_CONFIG"]
     end
-
-    cd(polymake)
-
-    withenv("CPP_FLAGS"=>"-I$vdir/include", "LD_LIBRARY_PATH"=>"$vdir/lib:$nemodir/lib") do
-       run(`$polymake/configure --prefix=$vdir --with-gmp=$nemovdir --with-mpfr=$nemovdir`)
-       withenv("LDFLAGS"=>LDFLAGS) do
-          run(`make -j4`)
-          run(`make install`)
-       end
-    end
-
-    ENV["POLYMAKE_CONFIG"] = "$pkgdir/local/bin/polymake-config"
 end
 
-pm_includes = chomp(readstring(`$(ENV["POLYMAKE_CONFIG"]) --includes`))
-pm_includes = map(i->i[3:end], map(String,split(pm_includes)))
-push!(pm_includes,Pkg.dir(pm_includes[1],"..","share","polymake"))
-pm_includes=join(pm_includes," ")
+if pm_config === nothing
+    # TODO: Install polymake, for now just throw an error
+    error("Set `POLYMAKE_CONFIG` ENV variable. And rebuild PolymakeWrap by calling `import Pkg; Pkg.build(\"PolymakeWrap\")`.")
 
-pm_cflags = chomp(readstring(`$(ENV["POLYMAKE_CONFIG"]) --cflags`))
-pm_ldflags = chomp(readstring(`$(ENV["POLYMAKE_CONFIG"]) --ldflags`))
-pm_libraries = chomp(readstring(`$(ENV["POLYMAKE_CONFIG"]) --libs`))
+    # This is the old Julia 0.6 script and doesnt work anymore.
+    #
+    # build polymake, using Nemo's GMP and MPFR
+    # const oldwdir = pwd()
+    # const pkgdir = Pkg.dir("PolymakeWrap")
+    # const nemodir = Pkg.dir("Nemo")
+    #
+    # wdir = "$pkgdir/deps"
+    # vdir = "$pkgdir/local"
+    # nemovdir = "$nemodir/local"
+    #
+    # LDFLAGS = "-Wl,-rpath,$vdir/lib -Wl,-R$vdir/lib -Wl,-R$nemovdir/lib -Wl,-R\$\$ORIGIN/../share/julia/site/v$(VERSION.major).$(VERSION.minor)/Polymake/local/lib"
+    #
+    # cd(wdir)
+    #
+    # const polymake = joinpath(wdir, "polymake")
+    #
+    # try
+    #   run(`git clone https://github.com/polymake/polymake.git`)
+    # catch
+    #   cd(polymake)
+    #   try
+    #      run(`git pull --rebase`)
+    #   catch
+    #   end
+    #   cd(wdir)
+    # end
+    #
+    # cd(polymake)
+    #
+    # withenv("CPP_FLAGS"=>"-I$vdir/include", "LD_LIBRARY_PATH"=>"$vdir/lib:$nemodir/lib") do
+    #    run(`$polymake/configure --prefix=$vdir --with-gmp=$nemovdir --with-mpfr=$nemovdir`)
+    #    withenv("LDFLAGS"=>LDFLAGS) do
+    #       run(`make -j4`)
+    #       run(`make install`)
+    #    end
+    # end
+    #
+    # ENV["POLYMAKE_CONFIG"] = "$pkgdir/local/bin/polymake-config"
+end
 
+pm_include_statements = read(`$pm_config --includes`, String) |> chomp |> split
+# Remove the -I prefix of all includes
+pm_include_statements = map(i -> i[3:end], pm_include_statements)
+push!(pm_include_statements, joinpath(pm_include_statements[1],"..","share","polymake"))
+pm_includes = join(pm_include_statements, " ")
 
-jlcxx_cmake_dir = Pkg.dir("CxxWrap", "deps", "usr", "lib", "cmake", "JlCxx")
+pm_cflags = chomp(read(`$pm_config --cflags`, String))
+pm_ldflags = chomp(read(`$pm_config --ldflags`, String))
+pm_libraries = chomp(read(`$pm_config --libs`, String))
 
-julia_include = Pkg.dir(JULIA_HOME,"..","include")
-julia_lib = Pkg.dir(JULIA_HOME,"..","lib")
-julia_exec = JULIA_HOME*"/julia"
+jlcxx_cmake_dir = joinpath(dirname(pathof(CxxWrap)), "..",  "deps", "usr", "lib", "cmake", "JlCxx")
 
-cmake_build_path = Pkg.dir("PolymakeWrap","deps","src")
+julia_include = joinpath(Sys.BINDIR, "..", "include")
+julia_lib = joinpath(Sys.BINDIR, "..", "lib")
+julia_exec = joinpath(Sys.BINDIR , "julia")
 
-cd(cmake_build_path)
+cd("src")
 
-run(`cmake Julia_EXECUTABLE=$julia_exec -DJlCxx_DIR=$jlcxx_cmake_dir -DJuliaIncludeDir=$julia_include -DJULIA_LIB_DIR=$julia_lib -Dpolymake_includes=$pm_includes -Dpolymake_ldflags=$pm_ldflags -Dpolymake_libs=$pm_libraries -Dpolymake_cflags=$pm_cflags -DCMAKE_INSTALL_LIBDIR=lib .`)
+run(`cmake -DJulia_EXECUTABLE=$julia_exec -DJlCxx_DIR=$jlcxx_cmake_dir -DJuliaIncludeDir=$julia_include -DJULIA_LIB_DIR=$julia_lib -Dpolymake_includes=$pm_includes -Dpolymake_ldflags=$pm_ldflags -Dpolymake_libs=$pm_libraries -Dpolymake_cflags=$pm_cflags -DCMAKE_INSTALL_LIBDIR=lib .`)
 run(`make`)

--- a/deps/src/polymake.cpp
+++ b/deps/src/polymake.cpp
@@ -208,9 +208,9 @@ struct WrappedSetIterator
   }
 };
 
-JULIA_CPP_MODULE_BEGIN(registry)
-  jlcxx::Module& polymake = registry.create_module("Polymake");
 
+JLCXX_MODULE define_module_polymake(jlcxx::Module& polymake)
+{
   polymake.add_type<pm::perl::PropertyValue>("pm_perl_PropertyValue");
   polymake.add_type<pm::perl::OptionSet>("pm_perl_OptionSet");
   polymake.add_type<pm::perl::Value>("pm_perl_Value");
@@ -219,8 +219,8 @@ JULIA_CPP_MODULE_BEGIN(registry)
     .constructor<const std::string&>()
     .method("give",[](pm::perl::Object p, const std::string& s){ return p.give(s); })
     .method("exists",[](pm::perl::Object p, const std::string& s){ return p.exists(s); })
-    .method("properties",[](pm::perl::Object p){ std::string x = p.call_method("properties"); 
-                                                 return x; 
+    .method("properties",[](pm::perl::Object p){ std::string x = p.call_method("properties");
+                                                 return x;
                                                 });
 
   polymake.add_type<pm::Integer>("pm_Integer")
@@ -402,5 +402,4 @@ JULIA_CPP_MODULE_BEGIN(registry)
 
 //   polymake.method("cube",[](pm::perl::Value a1, pm::perl::Value a2, pm::perl::Value a3, pm::perl::OptionSet opt){ return polymake::polytope::cube<pm::QuadraticExtension<pm::Rational> >(a1,a2,a3,opt); });
 
-
-JULIA_CPP_MODULE_END
+}

--- a/src/PolymakeWrap.jl
+++ b/src/PolymakeWrap.jl
@@ -13,8 +13,13 @@ module Polymake
         union, union!
 
     using CxxWrap
-    pm_dir = Pkg.dir("PolymakeWrap", "deps", "src","libpolymake.so")
-    wrap_module(pm_dir,Polymake)
+
+    @wrapmodule(joinpath(@__DIR__, "..", "deps", "src", "libpolymake.so"),
+        :define_module_polymake)
+
+    function __init__()
+        @initcxx
+    end
 end
 
 function __init__()


### PR DESCRIPTION
This makes things work on 0.7 / 1.0. For now the build script assumes that polymake is already installed on the users system, but I think this can easily be added back again.