### PR TITLE
Add basic pm::Rational support

### DIFF
--- a/deps/src/CMakeLists.txt
+++ b/deps/src/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(${MY_LIST})
 SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++14 ${polymake_cflags}" )
 SET( CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -L${JULIA_LIB_DIR} -Wl,-rpath,${JULIA_LIB_DIR} ${polymake_ldflags}" )
 
-add_library(polymake SHARED polymake.cpp polymake_functions.cpp polymake_integers.cpp polymake_sets.cpp polymake_caller.cpp)
+add_library(polymake SHARED polymake.cpp polymake_functions.cpp polymake_integers.cpp polymake_rationals.cpp polymake_sets.cpp polymake_caller.cpp)
 target_link_libraries(polymake JlCxx::cxxwrap_julia  -ljulia "${polymake_libs}")
 
 install(TARGETS

--- a/deps/src/polymake.cpp
+++ b/deps/src/polymake.cpp
@@ -6,6 +6,8 @@
 
 #include "polymake_integers.h"
 
+#include "polymake_rationals.h"
+
 #include "polymake_sets.h"
 
 #include "polymake_caller.h"
@@ -30,22 +32,10 @@ JLCXX_MODULE define_module_polymake(jlcxx::Module& polymake)
                                                 });
   POLYMAKE_INSERT_TYPE_IN_MAP(pm_perl_Object);
 
-  polymake.add_type<pm::Rational>("pm_Rational", jlcxx::julia_type("Real", "Base"))
-    .constructor<int32_t, int32_t>()
-    .constructor<int64_t, int64_t>()
-    .template constructor<pm::Integer, pm::Integer>()
-    .method("==", [](const pm::Rational& a, const pm::Rational& b){
-      return a == b;
-    })
-    .method("numerator",[](const pm::Rational& r){ return pm::Integer(numerator(r)); })
-    .method("denominator",[](const pm::Rational& r){ return pm::Integer(denominator(r));})
-    .method("show_small_obj", [](const pm::Rational& r){
-      return show_small_object<pm::Rational>(r, false);
-    });
-
   polymake_module_add_integer(polymake);
   POLYMAKE_INSERT_TYPE_IN_MAP(pm_Integer);
 
+  polymake_module_add_rational(polymake);
   POLYMAKE_INSERT_TYPE_IN_MAP(pm_Rational);
 
   polymake.add_type<jlcxx::Parametric<jlcxx::TypeVar<1>>>("pm_Matrix", jlcxx::julia_type("AbstractMatrix", "Base"))

--- a/deps/src/polymake_rationals.cpp
+++ b/deps/src/polymake_rationals.cpp
@@ -1,0 +1,81 @@
+#include "polymake_includes.h"
+
+#include "polymake_tools.h"
+
+#include "polymake_functions.h"
+
+#include "polymake_integers.h"
+
+#include "polymake_rationals.h"
+
+void polymake_module_add_rational(jlcxx::Module& polymake){
+
+  polymake.add_type<pm::Rational>("pm_Rational", jlcxx::julia_type("Real", "Base"))
+    .constructor<int32_t, int32_t>()
+    .constructor<int64_t, int64_t>()
+    .constructor<pm::Integer, pm::Integer>()
+    .method("==", [](pm::Rational& a, pm::Rational& b){ return a == b; })
+    .method("==",[](pm::Rational &a, pm::Integer &b){ return a == b; })
+    .method("==", [](pm::Rational& a, int64_t b){ return a == static_cast<long>(b); })
+    .method("==", [](pm::Rational& a, int32_t b){ return a == b; })
+    .method("==",[](pm::Integer &a, pm::Rational &b){ return a == b; })
+    .method("==", [](int64_t a, pm::Rational& b){ return static_cast<long>(a) == b; })
+    .method("==", [](int32_t a, pm::Rational& b){ return static_cast<long>(a) == b; })
+
+    .method("<", [](pm::Rational& a, pm::Rational& b){ return a < b; })
+    .method("<",[](pm::Rational &a, pm::Integer &b){ return a < b; })
+    .method("<", [](pm::Rational& a, int64_t b){ return a < static_cast<long>(b); })
+    .method("<", [](pm::Rational& a, int32_t b){ return a < b; })
+    .method("<",[](pm::Integer &a, pm::Rational &b){ return a < b; })
+    .method("<", [](int64_t a, pm::Rational& b){ return static_cast<long>(a) < b; })
+    .method("<", [](int32_t a, pm::Rational& b){ return static_cast<long>(a) < b; })
+
+    .method("<=", [](pm::Rational& a, pm::Rational& b){ return a <= b; })
+    .method("<=",[](pm::Rational &a, pm::Integer &b){ return a <= b; })
+    .method("<=", [](pm::Rational& a, int64_t b){ return a <= static_cast<long>(b); })
+    .method("<=", [](pm::Rational& a, int32_t b){ return a <= b; })
+    .method("<=",[](pm::Integer &a, pm::Rational &b){ return a <= b; })
+    .method("<=", [](int64_t a, pm::Rational& b){ return static_cast<long>(a) <= b; })
+    .method("<=", [](int32_t a, pm::Rational& b){ return a <= b; })
+
+    .method("numerator",[](const pm::Rational& r){ return pm::Integer(numerator(r)); })
+    .method("denominator",[](const pm::Rational& r){ return pm::Integer(denominator(r));})
+    .method("show_small_obj", [](const pm::Rational& r){
+      return show_small_object<pm::Rational>(r, false);
+    })
+    // the symmetric definitions are on the julia side
+    .method("+",[](pm::Rational &a, pm::Rational &b){ return a + b; })
+    .method("+",[](pm::Rational &a, pm::Integer &b){ return a + b; })
+    .method("+",[](pm::Rational &a, int64_t b){ return a + static_cast<long>(b); })
+    .method("+",[](pm::Rational &a, int32_t b){ return a + b; })
+    .method("+",[](pm::Integer &a, pm::Rational &b){ return a + b; })
+    .method("+",[](int64_t a, pm::Rational &b){ return static_cast<long>(a) + b; })
+    .method("+",[](int32_t a, pm::Rational &b){ return a + b; })
+
+    .method("*",[](pm::Rational &a, pm::Rational &b){ return a * b; })
+    .method("*",[](pm::Rational &a, pm::Integer &b){ return a * b; })
+    .method("*",[](pm::Rational &a, int64_t b){ return a * static_cast<long>(b); })
+    .method("*",[](pm::Rational &a, int32_t b){ return a * b; })
+    .method("*",[](pm::Integer &a, pm::Rational &b){ return a * b; })
+    .method("*",[](int64_t a, pm::Rational &b){ return static_cast<long>(a) * b; })
+    .method("*",[](int32_t a, pm::Rational &b){ return a * b; })
+
+    .method("-",[](pm::Rational &a, pm::Rational &b){ return a - b; })
+    .method("-",[](pm::Rational &a, pm::Integer &b){ return a - b; })
+    .method("-",[](pm::Rational &a, int64_t b){ return a - static_cast<long>(b); })
+    .method("-",[](pm::Rational &a, int32_t b){ return a - b; })
+    .method("-",[](pm::Integer &a, pm::Rational &b){ return a - b; })
+    .method("-",[](int64_t a, pm::Rational &b){ return static_cast<long>(a) - b; })
+    .method("-",[](int32_t a, pm::Rational &b){ return a - b; })
+    // unary minus
+    .method("-",[](pm::Rational &a){ return -a; })
+
+    .method("/",[](pm::Rational &a, pm::Rational &b){ return a / b; })
+    .method("/",[](pm::Rational &a, pm::Integer &b){ return a / b; })
+    .method("/",[](pm::Rational &a, int64_t b){ return a / static_cast<long>(b); })
+    .method("/",[](pm::Rational &a, int32_t b){ return a / b; })
+    .method("/",[](pm::Integer &a, pm::Rational &b){ return a / b; })
+    .method("/",[](int64_t a, pm::Rational &b){ return static_cast<long>(a) / b; })
+    .method("/",[](int32_t a, pm::Rational &b){ return a / b; });
+
+}

--- a/deps/src/polymake_rationals.h
+++ b/deps/src/polymake_rationals.h
@@ -1,0 +1,8 @@
+#ifndef POLYMAKE_WRAP_RATIONAL
+#define POLYMAKE_WRAP_RATIONAL
+
+#include "jlcxx/jlcxx.hpp"
+
+void polymake_module_add_rational(jlcxx::Module& polymake);
+
+#endif

--- a/src/PolymakeWrap.jl
+++ b/src/PolymakeWrap.jl
@@ -92,17 +92,9 @@ const SmallObject = Union{Polymake.pm_Integer,
 include("functions.jl")
 include("convert.jl")
 include("integers.jl")
+include("rationals.jl")
 include("sets.jl")
 # to be moved to Vectors/Matrices
-
-pm_Rational(num::T, den::T) where T<:Integer =
-    pm_Rational(pm_Integer(num), pm_Integer(den))
-pm_Rational(r::Rational) = pm_Rational(numerator(r), denominator(r))
-pm_Rational(int::Integer) = pm_Rational(int, one(int))
-
-Base.promote_rule(::Type{T}, ::Type{Polymake.pm_RationalAllocated}) where T <: Union{Integer, Rational} = pm_Rational
-
-convert(::Type{pm_Rational}, int::Integer) = pm_Rational(int)
 
 for (pm_T, Abstract_T) in [
             (:pm_Vector, :AbstractVector),

--- a/src/rationals.jl
+++ b/src/rationals.jl
@@ -1,0 +1,49 @@
+function Rational(frac::Polymake.pm_RationalAllocated)
+    Rational(BigInt(numerator(frac)), BigInt(denominator(frac)))
+end
+
+
+# Int32, Int64 constructors handled by Cxx side
+Polymake.pm_Rational(a::Int128, b::Int128) = Polymake.pm_Rational(big(a), big(b))
+function Polymake.pm_Rational(a::BigInt, b::BigInt)
+    Polymake.pm_Rational(pm_Integer(a), pm_Integer(b))
+end
+function Polymake.pm_Rational(x::Rational{<:Integer})
+    Polymake.pm_Rational(numerator(x), denominator(x))
+end
+# Fallback for same integer types -> convert to BigInt first
+function Polymake.pm_Rational(a::T, b::T) where {T<:Integer}
+    Polymake.pm_Rational(BigInt(a), BigInt(b))
+end
+# If we have different integer types, promote to common type first
+function Polymake.pm_Rational(a::Integer, b::Integer)
+    Polymake.pm_Rational(promote(a, b)...)
+end
+Polymake.pm_Rational(int::Integer) = pm_Rational(int, one(int))
+
+Base.one(i::Type{<:Polymake.pm_Rational}) = pm_Rational(1)
+Base.one(i::Polymake.pm_Rational) = pm_Rational(1)
+Base.zero(i::Polymake.pm_Rational) = pm_Rational(0)
+Base.zero(i::Type{<:Polymake.pm_Rational}) = pm_Rational(0)
+
+import Base: ==, <, <=
+# These are operations we delegate to gmp
+for op in (:(==), :(<), :(<=))
+    @eval begin
+        # These are all necessary to avoid ambiguities
+        $op(lhs::BigInt, rhs::Polymake.pm_Rational) = $op(pm_Integer(lhs),rhs)
+        $op(lhs::Polymake.pm_Rational, rhs::BigInt) = $op(lhs, pm_Integer(rhs))
+    end
+end
+
+function Base.promote_rule(::Type{Polymake.pm_Rational}, ::Type{<:Union{Int128, Int64, Int32}})
+    Polymake.pm_Rational
+end
+Base.promote_rule(::Type{<:Polymake.pm_Rational}, ::Type{BigInt}) = Polymake.pm_Rational
+Base.promote_rule(::Type{BigInt}, ::Type{<:Polymake.pm_Rational}) = Polymake.pm_Rational
+Base.promote_rule(::Type{<:Polymake.pm_Rational}, ::Type{<:Rational{<:Integer}}) = Polymake.pm_Rational
+Base.promote_rule(::Type{<:Rational{<:Integer}}, ::Type{<:Polymake.pm_Rational}) = Polymake.pm_Rational
+
+# Convert from Julia to PM
+Base.convert(::Type{<:Polymake.pm_Rational}, x::Integer) = Polymake.pm_Rational(x, one(x))
+Base.convert(::Type{<:Polymake.pm_Rational}, x::Rational) = Polymake.pm_Rational(x)

--- a/test/rationals.jl
+++ b/test/rationals.jl
@@ -1,0 +1,88 @@
+@testset "pm_Rational" begin
+    @testset "Constructors" begin
+        @test PolymakeWrap.pm_Rational(Int32(2), Int32(2)) isa PolymakeWrap.pm_Rational
+        @test PolymakeWrap.pm_Rational(Int64(2), Int64(5)) isa PolymakeWrap.pm_Rational
+        @test PolymakeWrap.pm_Rational(2, 4) isa PolymakeWrap.pm_Rational
+        @test PolymakeWrap.pm_Rational(big(2), big(4)) isa PolymakeWrap.pm_Rational
+        @test PolymakeWrap.pm_Rational(2 // 3) isa PolymakeWrap.pm_Rational
+        @test PolymakeWrap.pm_Rational(big(2) // big(3)) isa PolymakeWrap.pm_Rational
+        @test PolymakeWrap.pm_Rational(2, big(3)) isa PolymakeWrap.pm_Rational
+        @test PolymakeWrap.pm_Rational(big(3), 2) isa PolymakeWrap.pm_Rational
+        @test PolymakeWrap.pm_Rational(0) isa PolymakeWrap.pm_Rational
+
+        @test PolymakeWrap.pm_Rational <: Real
+    end
+
+    @testset "Equality" begin
+        a = PolymakeWrap.pm_Rational(2, 6)
+        for b in [Int32(2) // Int32(6), 2 // 6, big(2) // big(6)]
+            @test a == b
+            @test b == a
+        end
+
+        a = PolymakeWrap.pm_Rational(5, 1)
+        for b in [Int32(5), 5, big(5), PolymakeWrap.pm_Integer(5)]
+            @test a == b
+            @test b == a
+        end
+    end
+
+    @testset "zero / one" begin
+        a = PolymakeWrap.pm_Rational(0)
+        b = PolymakeWrap.pm_Rational(1)
+
+        @test one(a) isa PolymakeWrap.pm_Rational
+        @test zero(a) isa PolymakeWrap.pm_Rational
+        @test one(PolymakeWrap.pm_Rational) isa PolymakeWrap.pm_Rational
+        @test zero(PolymakeWrap.pm_Rational) isa PolymakeWrap.pm_Rational
+
+        @test one(PolymakeWrap.pm_Rational) == one(a) == 1 // 1 == 1
+        @test zero(PolymakeWrap.pm_Rational) == zero(a) == 0 // 1 == 0
+    end
+
+    @testset "Arithmetic" begin
+        a = PolymakeWrap.pm_Rational(2, 1)
+        @test -a == -2
+        for b in [Int32(5), Int64(5), big(5),
+                  PolymakeWrap.pm_Integer(5), PolymakeWrap.pm_Rational(5)]
+            # check promotion
+            @test a + b isa PolymakeWrap.pm_Rational
+            @test b + a isa PolymakeWrap.pm_Rational
+            @test a - b isa PolymakeWrap.pm_Rational
+            @test b - a isa PolymakeWrap.pm_Rational
+            @test a * b isa PolymakeWrap.pm_Rational
+            @test b * a isa PolymakeWrap.pm_Rational
+
+            # check arithmetic results
+            @test a + b == b + a == 7
+            @test a - b == -3
+            @test b - a == 3
+            @test a * b == b * a == 10
+            @test a / b == 2 // 5
+            @test b / a == 5 // 2
+        end
+
+        a = PolymakeWrap.pm_Rational(1, 14)
+        for b in [Int32(5) // Int32(7), 5 // 7, big(5 // 7), PolymakeWrap.pm_Rational(5, 7)]
+            # check promotion
+            @test a + b isa PolymakeWrap.pm_Rational
+            @test b + a isa PolymakeWrap.pm_Rational
+            @test a - b isa PolymakeWrap.pm_Rational
+            @test b - a isa PolymakeWrap.pm_Rational
+            @test a * b isa PolymakeWrap.pm_Rational
+            @test b * a isa PolymakeWrap.pm_Rational
+
+            # check arithmetic results
+            @test a + b == b + a == 11 // 14
+            @test a - b == -9 // 14
+            @test b - a == 9 // 14
+            @test a * b == b * a == 5 // 98
+        end
+    end
+
+    @testset "Show" begin
+        @test sprint(show, PolymakeWrap.pm_Rational(3, 5)) == "3/5"
+    end
+
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,49 +8,7 @@ end
 # write your own tests here
 @testset "PolymakeWrap" begin
     include("integers.jl")
-
-    @testset "pm_Rational" begin
-        pmI = PolymakeWrap.pm_Integer
-        pmR = PolymakeWrap.pm_Rational
-
-        function test_rational(num, den)
-            @test pmR(num, den) isa Number
-            @test pmR(num, den) isa Real
-            @test pmR(num, den) isa pmR
-
-            @test pmR(num//den) isa Number
-            @test pmR(num//den) isa Real
-            @test pmR(num//den) isa pmR
-            x = pmR(num, den)
-            @test numerator(x) isa PolymakeWrap.pm_Integer
-            @test numerator(x) == PolymakeWrap.pm_Integer(num)
-            @test denominator(x) isa PolymakeWrap.pm_Integer
-            @test denominator(x) == PolymakeWrap.pm_Integer(den)
-
-            @test pmR(num) isa pmR
-            return x
-        end
-
-        x = test_rational(Int32(4), Int32(3))
-        y = test_rational(4,3)
-        z = test_rational(big(4), big(3))
-
-        @test x == y == z == 4//3
-        @test pmR(pmI(4), pmI(3)) == x
-        @test x != pmR(4,4)
-
-        @test pmR(2, 4) == pmR(1, 2)
-        @test pmR(2//4) == pmR(1//2)
-        @test pmR(2, 4) == 1//2
-
-        @test pmR(3//4) == pmR(3, 4) == pmR(big(3)//4)== pmR(big(3), big(4))
-
-        str(a::pmR) = PolymakeWrap.Polymake.show_small_obj(a)
-        @test str(x) == str(y) == str(y) == "4/3"
-
-        @test one(pmR) == one(pmI)
-
-    end
+    include("rationals.jl")
 
     @testset "pm_Vector" begin
         pmV = PolymakeWrap.pm_Vector


### PR DESCRIPTION
This is basically an extension of #18 to the case of rationals. It also covers only basics, but should be sufficient for now.