### PR TITLE
Overload getproperty

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -33,8 +33,7 @@ function convert(::Type{Polymake.pm_Matrix{Polymake.pm_Integer}}, matrix::Array{
     pm_matrix = Polymake.pm_Matrix{Polymake.pm_Integer}(rows,cols)
     for i in 1:rows
         for j in 1:cols
-            converted = convert(Polymake.pm_Integer,matrix[i,j])
-            Polymake.set_entry(pm_matrix, i-1, j-1, converted )
+            pm_matrix[i,j] = matrix[i,j]
         end
     end
     return pm_matrix
@@ -45,8 +44,7 @@ function convert(::Type{Polymake.pm_Matrix{Polymake.pm_Rational}}, matrix::Array
     pm_matrix = Polymake.pm_Matrix{Polymake.pm_Rational}(rows,cols)
     for i in 1:rows
         for j in 1:cols
-            converted = convert(Polymake.pm_Rational,matrix[i,j])
-            Polymake.set_entry(pm_matrix, i-1, j-1, converted )
+            pm_matrix[i,j] = matrix[i,j]
         end
     end
     return pm_matrix
@@ -56,8 +54,7 @@ function convert(::Type{Polymake.pm_Vector{Polymake.pm_Integer}}, matrix::Array{
     (dim,) = size(matrix)
     pm_matrix = Polymake.pm_Vector{Polymake.pm_Integer}(dim)
     for i in 1:dim
-        converted = convert(Polymake.pm_Integer,matrix[i])
-        Polymake.set_entry(pm_matrix, i-1, converted )
+        pm_matrix[i] = matrix[i] 
     end
     return pm_matrix
 end
@@ -66,8 +63,7 @@ function convert(::Type{Polymake.pm_Vector{Polymake.pm_Rational}}, matrix::Array
     (dim,) = size(matrix)
     pm_matrix = Polymake.pm_Vector{Polymake.pm_Rational}(dim)
     for i in 1:dim
-        converted = convert(Polymake.pm_Rational,matrix[i])
-        Polymake.set_entry(pm_matrix, i-1, converted )
+        pm_matrix[i] = matrix[i]
     end
     return pm_matrix
 end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -51,6 +51,8 @@ function typename_func(typename::String)
     return identity
 end
 
+Base.getproperty(obj::Polymake.pm_perl_Object, prop::Symbol) = give(obj, string(prop))
+
 function give(obj::Polymake.pm_perl_Object,prop::String)
     return_obj = Polymake.give(obj,prop)
     type_name = Polymake.typeinfo_string(return_obj)

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -1,0 +1,17 @@
+@testset "perlobj" begin
+    input_dict_int = Dict( "POINTS" => [ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ] )
+    input_dict_rat = Dict( "POINTS" => Array{Rational{Int64},2}([ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]) )
+    pm_perl_Object = PolymakeWrap.Polymake.pm_perl_Object
+
+    @testset "constructors" begin
+        @test PolymakeWrap.perlobj("Polytope", input_dict_int ) isa pm_perl_Object
+        @test PolymakeWrap.perlobj("Polytope", input_dict_rat ) isa pm_perl_Object
+    end
+
+    @testset "output" begin
+        test_polytope = PolymakeWrap.perlobj("Polytope", input_dict_int )
+        @test PolymakeWrap.give(test_polytope,"F_VECTOR") == [ 4, 4 ]
+        @test PolymakeWrap.give(test_polytope,"INTERIOR_LATTICE_POINTS") ==
+            [ 1 1 1 ; 1 1 2 ; 1 2 1 ; 1 2 2 ]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,4 +177,5 @@ end
     end
 
     include("sets.jl")
+    include("perlobj.jl")
 end


### PR DESCRIPTION
This overloads `Base.getproperty` for `pm_perl_Object` to avoid this annoying `give` function.

```julia
julia>  PolymakeWrap.perlobj("Polytope", input_dict_rat )
type: Polytope<Rational>

POINTS
1 0 0
1 3 0
1 0 3
1 3 3



julia> P =  PolymakeWrap.perlobj("Polytope", input_dict_rat )
type: Polytope<Rational>

POINTS
1 0 0
1 3 0
1 0 3
1 3 3



julia> P.F_VECTOR
polymake: used package cdd
  cddlib
  Implementation of the double description method of Motzkin et al.
  Copyright by Komei Fukuda.
  http://www-oldurls.inf.ethz.ch/personal/fukudak/cdd_home/

polymake: used package lrs
  Implementation of the reverse search algorithm of Avis and Fukuda.
  Copyright by David Avis.
  http://cgm.cs.mcgill.ca/~avis/C/lrs.html

pm::Vector<pm::Integer>
4 4

julia> P.INTERIOR_LATTICE_POINTS
polymake: used package ppl
  The Parma Polyhedra Library (PPL): A C++ library for convex polyhedra
  and other numerical abstractions.
  http://www.cs.unipr.it/ppl/

pm::Matrix<pm::Integer>
1 1 1
1 1 2
1 2 1
1 2 2
```

This branch is #21 rebased onto master. So this should get merged first.